### PR TITLE
fix(auth): improve forgot password error message

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -88,7 +88,11 @@ function LoginContent() {
         });
 
         if (error) {
-            setMessage(`Error: ${error.message}`);
+            if (error.message === 'Error sending mail') {
+                setMessage('Error sending password reset email. This might be due to email provider configuration issues in your Supabase project. Please ensure that you have a custom SMTP provider configured and that the redirect URL is whitelisted in your Supabase project settings.');
+            } else {
+                setMessage(`Error: ${error.message}`);
+            }
         } else {
             setMessage('Password reset link sent! Please check your email.');
         }


### PR DESCRIPTION
The forgot password feature was failing with a generic "error sending mail" message. This is a common Supabase error that occurs when the email provider is not configured correctly or the redirect URL is not whitelisted.

This change improves the error message to guide the user on how to resolve the issue by checking their Supabase project settings.