### PR TITLE
fix(auth): Resolve race condition on mobile login

### DIFF
--- a/src/components/CapacitorAuthHandler.tsx
+++ b/src/components/CapacitorAuthHandler.tsx
@@ -31,7 +31,6 @@ const CapacitorAuthHandler = ({ children }: { children: React.ReactNode }) => {
           if (!error) {
             // Redirect to a protected route after successful session set
             router.push('/home');
-            router.refresh();
           } else {
             console.error('Error setting Supabase session:', error);
             // Optionally redirect to login with an error


### PR DESCRIPTION
The application failed to load correctly on the first sign-in on mobile devices. The UI would get stuck in a loading state until the app was manually restarted.

This was caused by a race condition in the `CapacitorAuthHandler` component. The `router.refresh()` function was called immediately after `supabase.auth.setSession()`. This created a conflict between the client-side session being set and a server-side data refresh being triggered before the server-side auth cookie was properly updated.

The fix removes the `router.refresh()` call. The application already has an `onAuthStateChange` listener within `UserDataProvider` that correctly handles the `SIGNED_IN` event, triggering a reliable client-side data fetch. This change ensures a predictable loading sequence by relying on the existing state management flow, resolving the race condition.