### PR TITLE
fix(data,db): Replace skills table query with hardcoded list and fix RLS

### DIFF
--- a/migration_history_rls.sql
+++ b/migration_history_rls.sql
@@ -1,0 +1,39 @@
+-- This migration script fixes the Row Level Security (RLS) policies
+-- for the skill_history table. The previous policies were too restrictive,
+-- causing 403 Forbidden errors when users tried to update their progress.
+
+-- By applying this migration, users will be able to select, insert, and
+-- update their own skill history records, which is required for the
+-- app to function correctly.
+
+-- Step 1: Policies for the `skill_history` table
+
+-- Ensure RLS is enabled on the table
+alter table public.skill_history enable row level security;
+
+-- Drop existing policies (if any) to start fresh.
+-- Note: Supabase might have created a default "manage all" policy.
+-- We drop it to replace it with more specific ones.
+drop policy if exists "Users can manage their own skill history." on public.skill_history;
+drop policy if exists "Users can view their own skill history." on public.skill_history;
+drop policy if exists "Users can insert their own skill history." on public.skill_history;
+drop policy if exists "Users can update their own skill history." on public.skill_history;
+
+-- Create a policy for SELECT
+-- This allows a user to read rows from skill_history if the user_id matches their own.
+create policy "Users can view their own skill history."
+on public.skill_history for select
+using (auth.uid() = user_id);
+
+-- Create a policy for INSERT
+-- This allows a user to insert a new row into skill_history if the user_id in the new row matches their own.
+create policy "Users can insert their own skill history."
+on public.skill_history for insert
+with check (auth.uid() = user_id);
+
+-- Create a policy for UPDATE
+-- This allows a user to update an existing row if the user_id of that row matches their own.
+create policy "Users can update their own skill history."
+on public.skill_history for update
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);

--- a/src/lib/skillsData.ts
+++ b/src/lib/skillsData.ts
@@ -1,0 +1,24 @@
+import type { Skill } from './types';
+
+export const allSkills: Skill[] = [
+  { id: 'skill_001', category: 'thinker', text: 'Spend 15 minutes analyzing a complex problem in your life or work.' },
+  { id: 'skill_002', category: 'builder', text: 'Build a small prototype of a new idea you have.' },
+  { id: 'skill_003', category: 'thinker', text: 'Read an article about a topic you know nothing about.' },
+  { id: 'skill_004', category: 'builder', text: 'Write a small script to automate a repetitive task.' },
+  { id: 'skill_005', category: 'builder', text: 'Organize a section of your workspace for better efficiency.' },
+  { id: 'skill_006', category: 'creator', text: 'Sketch or design a logo for a fictional company.' },
+  { id: 'skill_007', category: 'creator', text: 'Write a short story or a poem.' },
+  { id: 'skill_008', category: 'creator', text: 'Brainstorm 10 unconventional uses for a common object.' },
+  { id_009', category: 'creator', text: 'Create a playlist of music that inspires you.' },
+  { id: 'skill_010', category: 'thinker', text: 'Watch a documentary on a historical event.' },
+  { id: 'skill_011', category: 'thinker', text: 'Learn 5 new words in a foreign language.' },
+  { id: 'skill_012', category: 'thinker', text: 'Do a puzzle or play a strategy game.' },
+  { id: 'skill_013', category: 'thinker', text: 'Meditate for 10 minutes to clear your mind.' },
+  { id: 'skill_014', 'thinker', text: 'Plan your week ahead, setting clear goals.' },
+  { id: 'skill_015', category: 'thinker', text: 'Fact-check a news story you recently read.' },
+  { id: 'skill_016', category: 'connector', text: 'Reach out to a friend you haven\'t spoken to in a while.' },
+  { id: 'skill_017', category: 'connector', text: 'Post a helpful comment on a blog or social media post.' },
+  { id: 'skill_018', category: 'connector', text: 'Introduce two people you know who could benefit from meeting each other.' },
+  { id: 'skill_019', category: 'connector', text: 'Practice active listening in your next conversation.' },
+  { id: 'skill_020', category: 'connector', text: 'Share an interesting article or video with a friend.' },
+];


### PR DESCRIPTION
This commit addresses two core issues that were preventing the app from functioning:
1. A 404 Not Found error when fetching skills.
2. A 403 Forbidden error when updating skill history.

My investigation revealed that there is no `skills` table in the database; the skills were hardcoded inside a database function. The client-side code was incorrectly trying to query a non-existent table.

This commit fixes this by:
- Creating a new `src/lib/skillsData.ts` file to hold a hardcoded list of skills, mirroring the logic found in the database functions.
- Refactoring the server actions in `src/app/(app)/actions.ts` (`getSkillByIdAction` and `getNewSkillAction`) to use this hardcoded list instead of making a database call. This resolves the 404 error.

Additionally, a new migration file `migration_history_rls.sql` is added to correctly configure the Row Level Security policies for the `skill_history` table. The new policies allow users to select, insert, and update their own records, which resolves the 403 error.

The incorrect `migration_rls.sql` file has been removed.