### PR TITLE
Fix: Correct middleware logic to handle unauthenticated users

### DIFF
--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,5 +1,4 @@
 
-import {createFactory} from 'react';
 import {createClient} from '@/lib/supabase/server';
 import {NextResponse, type NextRequest} from 'next/server';
 
@@ -67,12 +66,12 @@ export async function updateSession(request: NextRequest) {
        const url = request.nextUrl.clone();
        url.pathname = '/home';
        return NextResponse.redirect(url);
-    } else if (!user && pathname === '/') {
-        // If user is logged out and hits the root, go to login.
-        const url = request.nextUrl.clone();
-        url.pathname = '/login';
-        return NextResponse.redirect(url);
     }
+  } else if (!user && pathname === '/') {
+      // If user is logged out and hits the root, go to login.
+      const url = request.nextUrl.clone();
+      url.pathname = '/login';
+      return NextResponse.redirect(url);
   }
 
 


### PR DESCRIPTION
The application was getting stuck on the initial loading screen because of a logical flaw in the middleware. A condition to handle unauthenticated users at the root path was incorrectly nested within a block for authenticated users, making it unreachable.

This commit corrects the middleware by:
1. Moving the `else if (!user && pathname === '/')` block to the correct level in the main logic chain.
2. Removing an unused and out-of-place `import` of `createFactory` from `react`.

This ensures that unauthenticated users are properly redirected to the login page, resolving the loading screen issue.